### PR TITLE
chore: Add NodeJS Oracle Database Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Table of Contents
 
 ## JavaScript
   * [JavaScript Extension Toolkit (JET)](https://oracle.com/jet) - collection of open source JavaScript libraries
+  * [NodeJS Oracle Database Driver](https://github.com/oracle/node-oracledb) - the official NodeJS driver to connect to Oracle Databases
 
 ## Machine Learning
   * [Tribuo](https://tribuo.org/) - Machine learning library written in Java


### PR DESCRIPTION
In my opinion, the official NodeJS npm package of Oracle to connect to the Oracle databases is an essential part of the NodeJS ecosystem for OCI.