### PR TITLE
Adding Cloud Services Availability per Region

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Table of Contents
       * Object Storage - 10 GB
 
     * Full, detailed list - https://www.oracle.com/cloud/free/
+    * [Oracle Cloud Services Availability per Region](https://www.oracle.com/cloud/data-regions/#northamerica)
 
 ## Container Platform
   * [Verrazzano](https://verrazzano.io/) - A hybrid multi-cloud Enterprise Container Platform


### PR DESCRIPTION
Added the link to the Oracle Cloud Services Availability per Region to give hints about what free service is available where.